### PR TITLE
Decrypt stored items when retrieving them

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ class SaveLocal {
   async get(item) {
     const hasItem = await storage.getItem(item)
 
-    return hasItem && hasItem
+    return hasItem && decrypt(hasItem, 20)
   }
 
   set(item) {


### PR DESCRIPTION
Looks like there was a regression recently that caused this to stop decrypting stored values when retrieving them. This fixes that.