### PR TITLE
add .init() method to initialize the local store

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
   - '8'
-  - '9'
   - '10'
+  - '12'

--- a/index.js
+++ b/index.js
@@ -6,10 +6,12 @@ const { encrypt, decrypt } = require('caesar-encrypt')
 
 class SaveLocal {
   constructor(store = 'storage') {
-    const s = `.${store}`
+    this.store = `.${store}`
+  }
 
-    storage.init({
-      dir: join(homedir(), s)
+  async init() {
+    await storage.init({
+      dir: join(homedir(), this.store)
     })
   }
 

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,9 @@ const SaveLocal = require('save-local')
 
 const saveLocal = new SaveLocal('store')
 
+// you must call saveLocal.init() to initialize the instance
+await saveLocal.init()
+
 saveLocal.set({ name: 'token', value: 'my-token' })
 saveLocal.get('token').then(value => console.log(value))
 // => my-token
@@ -37,6 +40,12 @@ Required
 store name
 
 ### methods
+
+#### .init()
+
+Returns a `promise`
+
+Initializes the local store
 
 #### .set([options])
 


### PR DESCRIPTION
The `node-persist` library requires an async initialization. This PR attempts to pass through the `.init()` call bootstrapping the persistence layer.

Also, the [git-labels-cli](https://github.com/marcuspoehls/git-labels-cli) requires this package to be updated to work properly again: https://github.com/bukinoshita/git-labels-cli/issues/24